### PR TITLE
Support all icon name cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ $ pub global activate icon_font_generator
 - `--normalize` - Normalize icons sizes, default: false
 
 ## Example
-*Atention*: Supports svg file names only in [`snake_case`](https://chaseonsoftware.com/most-common-programming-case-types/#snake_case) (like a `my_sepparated_icon_name.svg`, but not `my-icon.svg`, `my.icon.svg` etc)
-
-File structire:
+File structure:
 ```
 project
 └───icons
@@ -47,9 +45,9 @@ project
 ```
 Run command:
 ```
-$ icon_font_generator --from=icons --class-name=UiIcons --out-font=lib/src/icon_font/ui_icons.ttf --out-flutter=lib/src/widgets/icons.dart
+$ icon_font_generator --from=icons --class-name=UiIcons --out-font=lib/icon_font/ui_icons.ttf --out-flutter=lib/widgets/icons.dart
 ```
-Generated to:
+Generates:
 ```
 project
 └───icons

--- a/lib/generate_flutter_class.dart
+++ b/lib/generate_flutter_class.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:icon_font_generator/templates/flutter_icons.dart' as template;
-import 'package:register/register.dart';
+import 'package:recase/recase.dart';
 
 class GenerateResult {
   GenerateResult(this.content, this.iconsCount);
@@ -22,7 +22,7 @@ Future<GenerateResult> generateFlutterClass({
   final dartIconsEntryes = icons.entries.map(
     (entry) => someReplace(
       template.icon
-          .replaceFirst('%ICON_NAME%', Register(entry.key).camel)
+          .replaceFirst('%ICON_NAME%', ReCase(entry.key).camelCase)
           .replaceFirst('%ICON_CODE%', entry.value.replaceAll('\\', '')),
       className: className,
       indent: indent,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: Convert all *.svg icons from dir to icon-font (.ttf) and generates 
 environment: 
   sdk: '>=2.3.0-dev.0.5 <3.0.0'
 dependencies: 
-  register: ^1.0.1
+  recase: ^2.0.1
   args: ^1.5.2
   meta: ^1.1.6
   path: ^1.6.4


### PR DESCRIPTION
Support all icon name case spellings by replacing Register with ReCase which supports all string cases and can convert them to camelCase.