### PR TITLE
Make IconData private by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ project
 ```
 Generated icons.dart:
 ```dart
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
 import 'package:flutter/widgets.dart';
 
 @immutable
-class UiIconsData extends IconData {
+class _UiIconsData extends IconData {
   const UiIconsData(int codePoint)
       : super(
           codePoint,
@@ -82,14 +84,10 @@ class UiIconsData extends IconData {
 class UiIcons {
   UiIcons._();
 
-  // Generated code: do not hand-edit.
-  static const IconData account = UiIconsData(0xe000);
-
-  static const IconData arrowLeft = UiIconsData(0xe001);
-
-  static const IconData arrowRight = UiIconsData(0xe002);
-
-  static const IconData collection = UiIconsData(0xe003);
+  static const IconData account = _UiIconsData(0xe000);
+  static const IconData arrowLeft = _UiIconsData(0xe001);
+  static const IconData arrowRight = _UiIconsData(0xe002);
+  static const IconData collection = _UiIconsData(0xe003);
 }
 ```
 And also need add font to pubspec.yaml:

--- a/lib/generate_flutter_class.dart
+++ b/lib/generate_flutter_class.dart
@@ -19,7 +19,7 @@ Future<GenerateResult> generateFlutterClass({
 }) async {
   final Map<String, dynamic> icons = jsonDecode(await iconMap.readAsString());
 
-  final dartIconsEntryes = icons.entries.map(
+  final dartIconsEntries = icons.entries.map(
     (entry) => someReplace(
       template.icon
           .replaceFirst('%ICON_NAME%', Register(entry.key).camel)
@@ -43,7 +43,7 @@ Future<GenerateResult> generateFlutterClass({
                       indent: indent,
                     ),
             )
-            .replaceFirst('%CONTENT%', dartIconsEntryes.join('\n\n')),
+            .replaceFirst('%CONTENT%', dartIconsEntryes.join('\n')),
         className: className,
         indent: indent,
       ),

--- a/lib/generate_flutter_class.dart
+++ b/lib/generate_flutter_class.dart
@@ -43,7 +43,7 @@ Future<GenerateResult> generateFlutterClass({
                       indent: indent,
                     ),
             )
-            .replaceFirst('%CONTENT%', dartIconsEntryes.join('\n')),
+            .replaceFirst('%CONTENT%', dartIconsEntries.join('\n')),
         className: className,
         indent: indent,
       ),

--- a/lib/templates/flutter_icons.dart
+++ b/lib/templates/flutter_icons.dart
@@ -1,8 +1,10 @@
 const String base = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
 import 'package:flutter/widgets.dart';
 
 @immutable
-class %CLASS_NAME%Data extends IconData {
+class _%CLASS_NAME%Data extends IconData {
 %INDENT%const %CLASS_NAME%Data(int codePoint)
 %INDENT%%INDENT%%INDENT%: super(
 %INDENT%%INDENT%%INDENT%%INDENT%%INDENT%codePoint,
@@ -14,13 +16,13 @@ class %CLASS_NAME%Data extends IconData {
 class %CLASS_NAME% {
 %INDENT%%CLASS_NAME%._();
 
-%INDENT%// Generated code: do not hand-edit.
+%INDENT%
 %CONTENT%
 }
 ''';
 
 const String icon = '%INDENT%static const IconData %ICON_NAME% = '
-    '%CLASS_NAME%Data(0x%ICON_CODE%);';
+    '_%CLASS_NAME%Data(0x%ICON_CODE%);';
 
 const String package = '\n%INDENT%%INDENT%%INDENT%%INDENT%'
     '%INDENT%fontPackage: \'%PACKAGE_NAME%\',';


### PR DESCRIPTION
Don't expose generated IconData by default as it is not needed for using the icon font and it is a nicer style similar to how larger flutter icon libraries do it.

While I was at it I also fixed typos and improved the code generation with a clearer generated code message and less new lines.