### PR TITLE
Fix IconData constructor

### DIFF
--- a/lib/templates/flutter_icons.dart
+++ b/lib/templates/flutter_icons.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 
 @immutable
 class _%CLASS_NAME%Data extends IconData {
-%INDENT%const %CLASS_NAME%Data(int codePoint)
+%INDENT%const _%CLASS_NAME%Data(int codePoint)
 %INDENT%%INDENT%%INDENT%: super(
 %INDENT%%INDENT%%INDENT%%INDENT%%INDENT%codePoint,
 %INDENT%%INDENT%%INDENT%%INDENT%%INDENT%fontFamily: '%CLASS_NAME%',%PACKAGE%


### PR DESCRIPTION
#5 introduced an error in the IconData constructor that did not make reflect the private class in the constructor. This fixes that problem.

See https://github.com/rbcprolabs/icon_font_generator/pull/5#issuecomment-545425733