### PR TITLE
Add symlink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ pub global activate icon_font_generator
 - `--out-font` * - Output icon font path (to file, for example: lib/font.ttf)
 - `--out-flutter` * - Output flutter icon class (to file, for example: lib/icons.dart)
 - `--class-name` * - The class name is also the font name used in pubspec.yaml (as font name)
+- `--symlinks-map` - Source map of symlinked icons, have to be a json map with this pattern: target -> source
 - `--height` - Fixed font height value, defaults: 512
 - `--descent` - Offset applied to the baseline, defaults: 240
 - `--package` - Name of package for generated icon data ([See more](https://api.flutter.dev/flutter/widgets/IconData/fontPackage.html))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pub global activate icon_font_generator
 - `--out-font` * - Output icon font path (to file, for example: lib/font.ttf)
 - `--out-flutter` * - Output flutter icon class (to file, for example: lib/icons.dart)
 - `--class-name` * - The class name is also the font name used in pubspec.yaml (as font name)
-- `--symlinks-map` - Source map of symlinked icons, have to be a json map with this pattern: target -> source
+- `--symlinks-map` - Source map of symlinked icons, have to be a json map with this pattern: symlink -> target
 - `--height` - Fixed font height value, defaults: 512
 - `--descent` - Offset applied to the baseline, defaults: 240
 - `--package` - Name of package for generated icon data ([See more](https://api.flutter.dev/flutter/widgets/IconData/fontPackage.html))

--- a/bin/icon_font_generator.dart
+++ b/bin/icon_font_generator.dart
@@ -38,6 +38,10 @@ class GenerateCommand extends Command {
         help: 'Flutter class name / family for generating file',
       )
       ..addOption(
+        'symlinks-map',
+        help: 'Symlinked icons map source',
+      )
+      ..addOption(
         'height',
         help: 'Fixed font height value',
         defaultsTo: '512',
@@ -97,6 +101,12 @@ class GenerateCommand extends Command {
       exit(1);
     }
 
+    if (argResults!['symlinks-map'] != null &&
+        !argResults!['symlinks-map'].toString().endsWith('.json')) {
+      print('--symlinks-map have to be a .json file');
+      exit(1);
+    }
+
     final genRootDir = Directory.fromUri(Platform.script.resolve('..'));
 
     final npmPackage = File(path.join(genRootDir.path, 'package.json'));
@@ -139,6 +149,10 @@ class GenerateCommand extends Command {
 
     final sourceIconsDirectory = Directory.fromUri(Directory.current.uri
         .resolve(argResults!['from'].replaceAll('\\', '/')));
+    final symlinksMap = argResults!['symlinks-map'] == null
+        ? null
+        : File.fromUri(Directory.current.uri
+            .resolve(argResults!['symlinks-map'].replaceAll('\\', '/')));
     final outIconsFile = File.fromUri(Directory.current.uri
         .resolve(argResults!['out-font'].replaceAll('\\', '/')));
     final outFlutterClassFile = File.fromUri(Directory.current.uri
@@ -201,6 +215,7 @@ class GenerateCommand extends Command {
 
     final generateClassResult = await generateFlutterClass(
       iconMap: iconsMap,
+      symlinksMap: symlinksMap,
       className: argResults!['class-name'],
       packageName: argResults!['package'],
       namingStrategy: argResults!['naming-strategy'],

--- a/bin/icon_font_generator.dart
+++ b/bin/icon_font_generator.dart
@@ -39,7 +39,7 @@ class GenerateCommand extends Command {
       )
       ..addOption(
         'symlinks-map',
-        help: 'Symlinks json map, with this pattern: target -> source',
+        help: 'Symlinks json map, with this pattern: symlink -> target',
       )
       ..addOption(
         'height',

--- a/bin/icon_font_generator.dart
+++ b/bin/icon_font_generator.dart
@@ -39,7 +39,7 @@ class GenerateCommand extends Command {
       )
       ..addOption(
         'symlinks-map',
-        help: 'Symlinked icons map source',
+        help: 'Symlinks json map, with this pattern: target -> source',
       )
       ..addOption(
         'height',

--- a/lib/generate_flutter_class.dart
+++ b/lib/generate_flutter_class.dart
@@ -29,16 +29,20 @@ Future<GenerateResult> generateFlutterClass({
   final Map<String, dynamic> symlinks =
       symlinksMap == null ? {} : jsonDecode(await symlinksMap.readAsString());
 
-  final Iterable<String> reCasedIconKeys = icons.keys.map((key) => reCase(key));
-
   for (var symlinkEntry in symlinks.entries) {
     // Symlinks values are already correctly cased
     final symlink = symlinkEntry.key;
     final target = symlinkEntry.value.toString();
+    final Iterable<String> reCasedIconKeys =
+        icons.keys.map((key) => reCase(key));
 
     if (reCasedIconKeys.contains(symlink)) {
       print(
           '\x1B[33mWarning: symlink "$symlink" icon already exists - symlink creation skipped\x1B[0m');
+      continue;
+    } else if (symlinks.keys.contains(target)) {
+      print(
+          '\x1B[33mWarning: target "$target" icon is already a symlink - symlink creation skipped\x1B[0m');
       continue;
     } else if (!reCasedIconKeys.contains(target)) {
       print(

--- a/lib/generate_flutter_class.dart
+++ b/lib/generate_flutter_class.dart
@@ -13,12 +13,32 @@ class GenerateResult {
 
 Future<GenerateResult> generateFlutterClass({
   required File iconMap,
+  required File? symlinksMap,
   required String className,
   required String? packageName,
   required String namingStrategy,
   String indent = '  ',
 }) async {
   final Map<String, dynamic> icons = jsonDecode(await iconMap.readAsString());
+  final Map<String, dynamic> symlinks =
+      symlinksMap == null ? {} : jsonDecode(await symlinksMap.readAsString());
+
+  for (var symlinkEntry in symlinks.entries) {
+    final symlink = symlinkEntry.key;
+    final target = symlinkEntry.value.toString();
+    final targetEntry =
+        icons.entries.singleWhere((entry) => entry.key == target);
+
+    if (icons.keys.contains(symlink)) {
+      print(
+          '\x1B[33mWarning: "$symlink" icon already exists - symlink creation skipped\x1B[0m');
+      continue;
+    }
+
+    icons.addAll({
+      symlink: targetEntry.value,
+    });
+  }
 
   final dartIconsEntries = <String>{};
   final dartIconsValues = <String>{};


### PR DESCRIPTION
- [x] todo: update readme.md
- [x] todo: add check for missing target icon

## Usage

### Create a symlinks file

For an existent icon `target.svg`:

```json
{
    "symlink": "target"
}
```

Symlink is placed as key to avoid duplicate entries.
And like this, we can create different symlink of a target.

### Run cli

```bash
icon_font_generator --symlinks-map=path/to/symlinks.json ...
```

#### Error messages

If the symlink name already exist (as an existent icon or just as a symlink):
```
Warning: symlink "symlink" icon already exists - symlink creation skipped
```

If the target icon is a symlink:
```
Warning: target "target" icon is already a symlink - symlink creation skipped
```

If the target icon does not exist:
```
Warning: target "target" icon does not exist - symlink creation skipped
```

### Result

```dart
static const target = _IconsData(0xf101, 'target');
static const symlink = _IconsData(0xf101, 'symlink');
```

Closes #26