### PR TITLE
update run commands to use correct identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Compatible with dart2js and dart2native.
 $ flutter pub add --dev icon_font_generator
 
 # And it's ready to go:
-$ flutter pub run icon_font_generator:generate <input-svg-dir> <output-font-file> [options]
+$ flutter pub run icon_font_generator:generator <input-svg-dir> <output-font-file> [options]
 ```
 
 ### or [Globally activate][] the package:
@@ -31,7 +31,7 @@ $ flutter pub run icon_font_generator:generate <input-svg-dir> <output-font-file
 $ pub global activate icon_font_generator
 
 # And it's ready to go:
-$ icon_font_generator <input-svg-dir> <output-font-file> [options]
+$ generator <input-svg-dir> <output-font-file> [options]
 ```
 
 Required positional arguments:


### PR DESCRIPTION
It seems to me that, at least in version 4.0.0, the command name change to `generator`. 

I adjusted this in the README.md. 

In addition to that, when activating the package globally, I had to call `generator` directly instead of `icon_font_generator:generator`.