### PR TITLE
ADD ARGUMENT OPTIONS: --metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Name for a generated class.
 Name of a package that provides a font. Used to provide a font through package dependency.
 - `--[no-]format`
 Format dart generated code.
+- `--[no-]metadata`
+Includes base64-encoded images of the font in comments.
 
 Font options:
 - `-f` or `--font-name=<name>`
@@ -102,6 +104,7 @@ icon_font:
   class_name: "MyIcons"
   package: my_font_package
   format: true
+  metadata: true
 
   font_name: "My Icons"
   normalize: true

--- a/bin/generator.dart
+++ b/bin/generator.dart
@@ -87,6 +87,7 @@ void _run(CliArguments parsedArgs) {
     ignoreShapes: parsedArgs.ignoreShapes,
     normalize: parsedArgs.normalize,
     fontName: parsedArgs.fontName,
+    includeMeta: parsedArgs.includeMeta,
   );
 
   writeToFile(parsedArgs.fontFile.path, otfResult.font);

--- a/lib/src/cli/arguments.dart
+++ b/lib/src/cli/arguments.dart
@@ -25,11 +25,13 @@ const _kArgAllowedTypes = <CliArgument, List<Type>>{
   CliArgument.format: [bool],
   CliArgument.verbose: [bool],
   CliArgument.help: [bool],
+  CliArgument.includeMeta: [bool],
   CliArgument.configFile: [String],
 };
 
 const kDefaultVerbose = false;
 const kDefaultFormat = false;
+const kDefaultIncludeMeta = true;
 const kDefaultRecursive = false;
 
 const kOptionNames = EnumClass<CliArgument, String>({
@@ -39,6 +41,7 @@ const kOptionNames = EnumClass<CliArgument, String>({
   CliArgument.className: 'class-name',
   CliArgument.fontPackage: 'package',
   CliArgument.format: 'format',
+  CliArgument.includeMeta: 'metadata',
 
   CliArgument.fontName: 'font-name',
   CliArgument.normalize: 'normalize',
@@ -59,6 +62,7 @@ const kConfigKeys = EnumClass<CliArgument, String>({
   CliArgument.className: 'class_name',
   CliArgument.fontPackage: 'package',
   CliArgument.format: 'format',
+  CliArgument.includeMeta: 'metadata',
 
   CliArgument.fontName: 'font_name',
   CliArgument.normalize: 'normalize',
@@ -85,6 +89,7 @@ enum CliArgument {
   className,
   fontPackage,
   format,
+  includeMeta,
 
   // Font-related
   fontName,
@@ -109,6 +114,7 @@ class CliArguments {
     this.className,
     this.fontPackage,
     this.format,
+    this.includeMeta,
     this.fontName,
     this.recursive,
     this.ignoreShapes,
@@ -131,6 +137,7 @@ class CliArguments {
       map[CliArgument.className] as String?,
       map[CliArgument.fontPackage] as String?,
       map[CliArgument.format] as bool?,
+      map[CliArgument.includeMeta] as bool?,
       map[CliArgument.fontName] as String?,
       map[CliArgument.recursive] as bool?,
       map[CliArgument.ignoreShapes] as bool?,
@@ -146,6 +153,7 @@ class CliArguments {
   final String? className;
   final String? fontPackage;
   final bool? format;
+  final bool? includeMeta;
   final String? fontName;
   final bool? recursive;
   final bool? ignoreShapes;

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -30,6 +30,11 @@ void defineOptions(ArgParser argParser) {
       help: 'Formate dart generated code.',
       defaultsTo: kDefaultFormat,
     )
+    ..addFlag(
+      kOptionNames[CliArgument.includeMeta]!,
+      help: 'Includes base64 comments of a font.',
+      defaultsTo: kDefaultIncludeMeta,
+    )
     ..addSeparator('Font options:')
     ..addOption(
       kOptionNames[CliArgument.fontName]!,

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -32,7 +32,7 @@ void defineOptions(ArgParser argParser) {
     )
     ..addFlag(
       kOptionNames[CliArgument.includeMeta]!,
-      help: 'Includes base64 comments of a font.',
+      help: 'Includes base64-encoded images of the font in comments.',
       defaultsTo: kDefaultIncludeMeta,
     )
     ..addSeparator('Font options:')

--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -32,8 +32,10 @@ SvgToOtfResult svgToOtf({
   bool? ignoreShapes,
   bool? normalize,
   String? fontName,
+  bool? includeMeta,
 }) {
   normalize ??= true;
+  includeMeta ??= true;
 
   final svgList = [
     for (final e in svgMap.entries)
@@ -53,7 +55,9 @@ SvgToOtfResult svgToOtf({
     }
   }
 
-  final glyphList = svgList.map(GenericGlyph.fromSvg).toList();
+  final glyphList = svgList
+      .map((svg) => GenericGlyph.fromSvg(svg, includeMeta: includeMeta))
+      .toList();
 
   final font = OpenTypeFont.createFromGlyphs(
     glyphList: glyphList,

--- a/lib/src/common/generic_glyph.dart
+++ b/lib/src/common/generic_glyph.dart
@@ -94,7 +94,10 @@ class GenericGlyph {
     return GenericGlyph(outlines, bounds);
   }
 
-  factory GenericGlyph.fromSvg(Svg svg) {
+  factory GenericGlyph.fromSvg(
+    Svg svg, {
+    bool? includeMeta,
+  }) {
     final pathList = svg.elementList.whereType<PathElement>();
 
     final outlines = [
@@ -106,7 +109,7 @@ class GenericGlyph {
       ratioX: svg.ratioX,
       ratioY: svg.ratioY,
       offset: svg.offset,
-      preview: svg.toBase64(),
+      preview: includeMeta == true ? svg.toBase64() : null,
     );
 
     return GenericGlyph(outlines, svg.viewBox, metadata);


### PR DESCRIPTION
I found a problem with generating a large icon set into TTF files: the generated Dart file becomes too large due to the base64 encoded image of the font in a comment. This PR adds an option to exclude the base64 encoding for a smaller Dart file size.