### PR TITLE
Implementing argument for fontWeight

### DIFF
--- a/lib/src/cli/arguments.dart
+++ b/lib/src/cli/arguments.dart
@@ -43,6 +43,7 @@ const kOptionNames = EnumClass<CliArgument, String>({
   CliArgument.fontName: 'font-name',
   CliArgument.normalize: 'normalize',
   CliArgument.ignoreShapes: 'ignore-shapes',
+  CliArgument.fontWeight: 'font-weight',
 
   CliArgument.recursive: 'recursive',
   CliArgument.verbose: 'verbose',
@@ -90,6 +91,7 @@ enum CliArgument {
   fontName,
   ignoreShapes,
   normalize,
+  fontWeight,
 
   // Others
   recursive,
@@ -112,6 +114,7 @@ class CliArguments {
     this.fontName,
     this.recursive,
     this.ignoreShapes,
+    this.fontWeight,
     this.normalize,
     this.verbose,
     this.configFile,
@@ -134,6 +137,7 @@ class CliArguments {
       map[CliArgument.fontName] as String?,
       map[CliArgument.recursive] as bool?,
       map[CliArgument.ignoreShapes] as bool?,
+      int.tryParse((map[CliArgument.fontWeight] as String?) ?? ''),
       map[CliArgument.normalize] as bool?,
       map[CliArgument.verbose] as bool?,
       map[CliArgument.configFile] as File?,
@@ -149,6 +153,7 @@ class CliArguments {
   final String? fontName;
   final bool? recursive;
   final bool? ignoreShapes;
+  final int? fontWeight;
   final bool? normalize;
   final bool? verbose;
   final File? configFile;

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -43,6 +43,11 @@ void defineOptions(ArgParser argParser) {
           'Enables glyph normalization for the font. Disable this if every icon has the same size and positioning.',
       defaultsTo: true,
     )
+    ..addOption(
+      kOptionNames[CliArgument.fontWeight]!,
+      help: 'Provide font weight (from 100 to 900).',
+      defaultsTo: '400',
+    )
     ..addFlag(
       kOptionNames[CliArgument.ignoreShapes]!,
       help: 'Disables SVG shape-to-path conversion (circle, rect, etc.).',

--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -32,6 +32,7 @@ SvgToOtfResult svgToOtf({
   bool? ignoreShapes,
   bool? normalize,
   String? fontName,
+  int? fontWeight,
 }) {
   normalize ??= true;
 
@@ -59,6 +60,7 @@ SvgToOtfResult svgToOtf({
     glyphList: glyphList,
     fontName: fontName,
     normalize: normalize,
+    fontWeight: fontWeight,
     useOpenType: true,
     usePostV2: true,
   );

--- a/lib/src/otf/otf.dart
+++ b/lib/src/otf/otf.dart
@@ -68,6 +68,7 @@ class OpenTypeFont implements BinaryCodable {
     bool? useOpenType,
     bool? usePostV2,
     bool? normalize,
+    int? fontWeight,
   }) {
     if (fontName?.isEmpty ?? false) {
       fontName = null;
@@ -136,7 +137,8 @@ class OpenTypeFont implements BinaryCodable {
     final maxp = MaximumProfileTable.create(fullGlyphList.length, glyf);
     final cmap = CharacterToGlyphTable.create(fullGlyphList);
     final gsub = GlyphSubstitutionTable.create();
-    final os2 = OS2Table.create(hmtx, head, hhea, cmap, gsub, achVendID);
+    final os2 = OS2Table.create(hmtx, head, hhea, cmap, gsub, achVendID,
+        fontWeight: fontWeight);
 
     final cff =
         useOpenType ? CFF1Table.create(fullGlyphList, head, hmtx, name) : null;

--- a/lib/src/otf/table/os2.dart
+++ b/lib/src/otf/table/os2.dart
@@ -149,6 +149,7 @@ class OS2Table extends FontTable {
     GlyphSubstitutionTable gsub,
     String achVendID, {
     int version = _kVersion5,
+    int? fontWeight,
   }) {
     final asciiAchVendID = achVendID.getAsciiPrintable();
 
@@ -180,7 +181,7 @@ class OS2Table extends FontTable {
         null,
         version,
         _getAverageWidth(hmtx),
-        400, // Regular weight
+        fontWeight ?? 400, // Regular weight
         5, // Normal width
         0, // Installable embedding
         scriptXsize,


### PR DESCRIPTION
This PR adds support for FontWeight in the IconFontGenerator. With this update, it is now possible to specify different font weights when generating icons, allowing users to use fonts with weight variations in their Flutter projects.

