### PR TITLE
Rename confusing package flag, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Name of a package that provides a font. Used to provide a font through package d
 Format dart generated code.
 
 Font options:
-- `-f` or `--font-name=<name>`
+- `-n` or `--font-name=<name>`
 Name for a generated font.
 - `--[no-]normalize`
 Enables glyph normalization for the font.

--- a/lib/src/cli/options.dart
+++ b/lib/src/cli/options.dart
@@ -20,7 +20,7 @@ void defineOptions(ArgParser argParser) {
     )
     ..addOption(
       kOptionNames[CliArgument.fontPackage]!,
-      abbr: 'f',
+      abbr: 'p',
       help:
           'Name of a package that provides a font. Used to provide a font through package dependency.',
       valueHelp: 'name',


### PR DESCRIPTION
Renames the `--package` short flag to `-p` consistent with the README, and updates README to use the correct `-n` for `--font-name`

**This is a breaking change**

Fixes #52