### PR TITLE
feat: optional explicit charCodes map in svgToOtf (+ deterministic output)

### DIFF
--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -25,10 +25,14 @@ class SvgToOtfResult {
 /// glyphs are resized and centered to fit in coordinates grid (unitsPerEm).
 /// Defaults to true.
 /// * [fontName] is a name for a generated font.
+/// * If [charCodes] is provided, each glyph named `n` is assigned codepoint
+/// `charCodes[n]` instead of the default sequential `0xE000 + index`
+/// assignment. Throws [ArgumentError] if a glyph's name is missing from the map.
 ///
 /// Returns an instance of [SvgToOtfResult] class containing glyphs and a font.
 SvgToOtfResult svgToOtf({
   required Map<String, String> svgMap,
+  Map<String, int>? charCodes,
   bool? ignoreShapes,
   bool? normalize,
   String? fontName,
@@ -61,6 +65,7 @@ SvgToOtfResult svgToOtf({
     normalize: normalize,
     useOpenType: true,
     usePostV2: true,
+    charCodes: charCodes,
   );
 
   return SvgToOtfResult._(glyphList, font);

--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -26,8 +26,13 @@ class SvgToOtfResult {
 /// Defaults to true.
 /// * [fontName] is a name for a generated font.
 /// * If [charCodes] is provided, each glyph named `n` is assigned codepoint
-/// `charCodes[n]` instead of the default sequential `0xE000 + index`
-/// assignment. Throws [ArgumentError] if a glyph's name is missing from the map.
+/// `charCodes[n]` instead of the default sequential
+/// `kUnicodePrivateUseAreaStart + index` assignment. Glyphs are reordered by
+/// their assigned codepoint so the generated cmap stays valid. Each codepoint
+/// must be unique and within the BMP range `0x21..0xFFFE` (the space `0x20`
+/// and the cmap terminator `0xFFFF` are reserved). Throws [ArgumentError] if a
+/// glyph's name is missing from the map or its codepoint is out of range or
+/// duplicated.
 ///
 /// Returns an instance of [SvgToOtfResult] class containing glyphs and a font.
 SvgToOtfResult svgToOtf({

--- a/lib/src/otf/cff/variations.dart
+++ b/lib/src/otf/cff/variations.dart
@@ -97,7 +97,9 @@ class VariationRegionList extends BinaryCodable {
 
   @override
   void encodeToBinary(ByteData byteData) {
-    byteData..setUint16(0, axisCount)..setUint16(2, regionCount);
+    byteData
+      ..setUint16(0, axisCount)
+      ..setUint16(2, regionCount);
 
     for (var r = 0; r < regionCount; r++) {
       for (var a = 0; a < axisCount; a++) {

--- a/lib/src/otf/otf.dart
+++ b/lib/src/otf/otf.dart
@@ -304,6 +304,12 @@ class OpenTypeFont implements BinaryCodable {
   // reserves 0xFFFF as its mandatory terminator segment.
   static const _kMaxCharCode = 0xFFFF - 1;
 
+  // The UTF-16 surrogate block is reserved and is never a valid Unicode scalar
+  // value, so a surrogate written into the cmap yields a font consumers cannot
+  // look up. It falls inside the BMP range above, so exclude it explicitly.
+  static const _kSurrogateStart = 0xD800;
+  static const _kSurrogateEnd = 0xDFFF;
+
   static List<GenericGlyph> _applyCharCodes(
       List<GenericGlyph> glyphList, Map<String, int> charCodes) {
     final usedCharCodes = <int>{};
@@ -318,11 +324,15 @@ class OpenTypeFont implements BinaryCodable {
 
       // Codepoints outside this range corrupt the BMP-only cmap format 4 and
       // OS/2 tables (values above 0xFFFF are silently truncated by the 16-bit
-      // encoders) or collide with the reserved space/terminator codepoints.
-      if (charCode < _kMinCharCode || charCode > _kMaxCharCode) {
+      // encoders) or collide with the reserved space/terminator codepoints;
+      // surrogates are reserved and never valid cmap entries.
+      if (charCode < _kMinCharCode ||
+          charCode > _kMaxCharCode ||
+          (charCode >= _kSurrogateStart && charCode <= _kSurrogateEnd)) {
         throw ArgumentError('Codepoint for glyph "$name" must be in the range '
             '$_kMinCharCode..$_kMaxCharCode (BMP, excluding the reserved '
-            'space and cmap terminator codepoints), got $charCode');
+            'space, cmap terminator, and UTF-16 surrogate codepoints), '
+            'got $charCode');
       }
 
       if (!usedCharCodes.add(charCode)) {

--- a/lib/src/otf/otf.dart
+++ b/lib/src/otf/otf.dart
@@ -296,16 +296,48 @@ class OpenTypeFont implements BinaryCodable {
     return glyphList;
   }
 
+  // Lowest assignable codepoint: must be above the reserved space glyph (0x20)
+  // so custom glyphs always sort after it in the cmap.
+  static const _kMinCharCode = kUnicodeSpaceCharCode + 1;
+
+  // Highest assignable codepoint: the cmap format 4 subtable is BMP-only and
+  // reserves 0xFFFF as its mandatory terminator segment.
+  static const _kMaxCharCode = 0xFFFF - 1;
+
   static List<GenericGlyph> _applyCharCodes(
       List<GenericGlyph> glyphList, Map<String, int> charCodes) {
+    final usedCharCodes = <int>{};
+
     for (final glyph in glyphList) {
       final name = glyph.metadata.name;
-      final cp = charCodes[name];
-      if (cp == null) {
+      final charCode = charCodes[name];
+
+      if (charCode == null) {
         throw ArgumentError('No codepoint provided for glyph "$name"');
       }
-      glyph.metadata.charCode = cp;
+
+      // Codepoints outside this range corrupt the BMP-only cmap format 4 and
+      // OS/2 tables (values above 0xFFFF are silently truncated by the 16-bit
+      // encoders) or collide with the reserved space/terminator codepoints.
+      if (charCode < _kMinCharCode || charCode > _kMaxCharCode) {
+        throw ArgumentError('Codepoint for glyph "$name" must be in the range '
+            '$_kMinCharCode..$_kMaxCharCode (BMP, excluding the reserved '
+            'space and cmap terminator codepoints), got $charCode');
+      }
+
+      if (!usedCharCodes.add(charCode)) {
+        throw ArgumentError(
+            'Duplicate codepoint $charCode assigned to glyph "$name"');
+      }
+
+      glyph.metadata.charCode = charCode;
     }
+
+    // cmap format 4/12 segment generation assumes char codes are ascending in
+    // glyph order, so sort glyphs by their assigned codepoint before returning.
+    glyphList
+        .sort((a, b) => a.metadata.charCode!.compareTo(b.metadata.charCode!));
+
     return glyphList;
   }
 

--- a/lib/src/otf/otf.dart
+++ b/lib/src/otf/otf.dart
@@ -68,6 +68,7 @@ class OpenTypeFont implements BinaryCodable {
     bool? useOpenType,
     bool? usePostV2,
     bool? normalize,
+    Map<String, int>? charCodes,
   }) {
     if (fontName?.isEmpty ?? false) {
       fontName = null;
@@ -80,7 +81,9 @@ class OpenTypeFont implements BinaryCodable {
     normalize ??= true;
     usePostV2 ??= false;
 
-    glyphList = _generateCharCodes(glyphList);
+    glyphList = charCodes != null
+        ? _applyCharCodes(glyphList, charCodes)
+        : _generateCharCodes(glyphList);
 
     // A power of two is recommended only for TrueType outlines
     final unitsPerEm =
@@ -289,6 +292,19 @@ class OpenTypeFont implements BinaryCodable {
   static List<GenericGlyph> _generateCharCodes(List<GenericGlyph> glyphList) {
     for (var i = 0; i < glyphList.length; i++) {
       glyphList[i].metadata.charCode = kUnicodePrivateUseAreaStart + i;
+    }
+    return glyphList;
+  }
+
+  static List<GenericGlyph> _applyCharCodes(
+      List<GenericGlyph> glyphList, Map<String, int> charCodes) {
+    for (final glyph in glyphList) {
+      final name = glyph.metadata.name;
+      final cp = charCodes[name];
+      if (cp == null) {
+        throw ArgumentError('No codepoint provided for glyph "$name"');
+      }
+      glyph.metadata.charCode = cp;
     }
     return glyphList;
   }

--- a/lib/src/otf/table/coverage.dart
+++ b/lib/src/otf/table/coverage.dart
@@ -43,7 +43,9 @@ class CoverageTableFormat1 extends CoverageTable {
 
   @override
   void encodeToBinary(ByteData byteData) {
-    byteData..setUint16(0, coverageFormat)..setUint16(2, glyphCount);
+    byteData
+      ..setUint16(0, coverageFormat)
+      ..setUint16(2, glyphCount);
 
     for (var i = 0; i < glyphCount; i++) {
       byteData.setInt16(4 + 2 * i, glyphArray[i]);

--- a/lib/src/otf/table/feature_list.dart
+++ b/lib/src/otf/table/feature_list.dart
@@ -62,7 +62,9 @@ class FeatureTable implements BinaryCodable {
 
   @override
   void encodeToBinary(ByteData byteData) {
-    byteData..setUint16(0, featureParams)..setUint16(2, lookupIndexCount);
+    byteData
+      ..setUint16(0, featureParams)
+      ..setUint16(2, lookupIndexCount);
 
     for (var i = 0; i < lookupIndexCount; i++) {
       byteData.setInt16(4 + 2 * i, lookupListIndices[i]);

--- a/lib/src/otf/table/name.dart
+++ b/lib/src/otf/table/name.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import '../../common/codable/binary.dart';
 import '../../common/constant.dart';
 import '../../utils/enum_class.dart';
+import '../../utils/misc.dart';
 import '../../utils/otf.dart';
 import '../../utils/ucs2.dart';
 import '../debugger.dart';
@@ -263,7 +264,7 @@ class NamingTableFormat0 extends NamingTable {
 
   factory NamingTableFormat0.create(
       String fontName, String? description, Revision revision) {
-    final now = DateTime.now();
+    final now = MockableDateTime.now();
 
     /// Values for name ids in sorted order
     final stringForNameMap = <NameID, String>{

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,2 +1,3 @@
 export 'utils/exception.dart';
 export 'utils/flutter_class_gen.dart';
+export 'utils/misc.dart' show MockableDateTime;

--- a/test/charcodes_test.dart
+++ b/test/charcodes_test.dart
@@ -8,9 +8,49 @@ void main() {
   test('svgToOtf honours explicit charCodes', () {
     final result = svgToOtf(
       svgMap: {'square': _squareSvg},
-      charCodes: {'square': 0xF1234},
+      charCodes: {'square': 0xF123},
     );
-    final glyph = result.glyphList.firstWhere((g) => g.metadata.name == 'square');
-    expect(glyph.metadata.charCode, 0xF1234);
+    final glyph =
+        result.glyphList.firstWhere((g) => g.metadata.name == 'square');
+    expect(glyph.metadata.charCode, 0xF123);
+  });
+
+  test('svgToOtf sorts glyphs by explicit codepoint', () {
+    final result = svgToOtf(
+      svgMap: {'b': _squareSvg, 'a': _squareSvg},
+      charCodes: {'b': 0xF002, 'a': 0xF001},
+    );
+    final codes = result.glyphList.map((g) => g.metadata.charCode).toList();
+    expect(codes, orderedEquals(<int>[0xF001, 0xF002]));
+  });
+
+  test('svgToOtf rejects a glyph missing from charCodes', () {
+    expect(
+      () => svgToOtf(
+        svgMap: {'square': _squareSvg},
+        charCodes: {'other': 0xF001},
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('svgToOtf rejects duplicate codepoints', () {
+    expect(
+      () => svgToOtf(
+        svgMap: {'a': _squareSvg, 'b': _squareSvg},
+        charCodes: {'a': 0xF001, 'b': 0xF001},
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('svgToOtf rejects non-BMP codepoints', () {
+    expect(
+      () => svgToOtf(
+        svgMap: {'square': _squareSvg},
+        charCodes: {'square': 0xF1234},
+      ),
+      throwsArgumentError,
+    );
   });
 }

--- a/test/charcodes_test.dart
+++ b/test/charcodes_test.dart
@@ -53,4 +53,14 @@ void main() {
       throwsArgumentError,
     );
   });
+
+  test('svgToOtf rejects surrogate codepoints', () {
+    expect(
+      () => svgToOtf(
+        svgMap: {'square': _squareSvg},
+        charCodes: {'square': 0xD800},
+      ),
+      throwsArgumentError,
+    );
+  });
 }

--- a/test/charcodes_test.dart
+++ b/test/charcodes_test.dart
@@ -1,0 +1,16 @@
+import 'package:icon_font_generator/icon_font_generator.dart';
+import 'package:test/test.dart';
+
+const _squareSvg =
+    '<svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18"/></svg>';
+
+void main() {
+  test('svgToOtf honours explicit charCodes', () {
+    final result = svgToOtf(
+      svgMap: {'square': _squareSvg},
+      charCodes: {'square': 0xF1234},
+    );
+    final glyph = result.glyphList.firstWhere((g) => g.metadata.name == 'square');
+    expect(glyph.metadata.charCode, 0xF1234);
+  });
+}

--- a/test/test_all.dart
+++ b/test/test_all.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 
+import 'charcodes_test.dart' as charcodes;
 import 'cli_test.dart' as cli;
 import 'normalize_test.dart' as norm;
 import 'ttf_test.dart' as ttf;
@@ -8,4 +9,5 @@ void main() {
   group('TTF', ttf.main);
   group('CLI', cli.main);
   group('Normalization', norm.main);
+  group('CharCodes', charcodes.main);
 }


### PR DESCRIPTION
## What

Adds an optional `charCodes` parameter to `svgToOtf` so callers can assign an explicit codepoint to each glyph by name, instead of relying on the implicit sequential assignment. When omitted, behaviour is unchanged.

```dart
svgToOtf(
  svgMap: {'arrow-left': '<svg .../>'},
  charCodes: {'arrow-left': 0xE001}, // pin this glyph to U+E001
);
```

This enables downstream tools to keep a glyph's codepoint stable across regenerations (e.g. an append-only icon set that must not remap existing icons on every build).

## Commits

1. **feat: optional explicit `charCodes` map in `svgToOtf`** — the parameter, plus deterministic glyph sorting by codepoint so the emitted cmap order is stable.
2. **fix: deterministic font output** — exposes `MockableDateTime` so the `head` (created/modified) and `name` (copyright year) tables can be pinned. Without this the engine stamps the wall clock into the font, so two builds of identical input produce different bytes — which breaks byte-level drift checks and reproducible builds.
3. **fix: harden explicit `charCodes` against invalid cmap generation** — validates each explicit codepoint is inside the BMP (`0x21..0xFFFE`). The cmap format-4 subtable is BMP-only; a value above `0xFFFF` is silently truncated by the 16-bit encoder (`setUint16(0xF1234) == 0x1234`), producing a malformed cmap. Rejects duplicates and glyphs missing from the map too.
4. **fix: reject surrogate codepoints** — the UTF-16 surrogate block (`0xD800..0xDFFF`) sits inside the BMP range but is never a valid Unicode scalar value, so it is excluded explicitly.

## Tests

New `test/charcodes_test.dart` (registered in `test_all.dart`) covers: explicit assignment, codepoint sorting, missing-glyph rejection, duplicate rejection, non-BMP rejection, and surrogate rejection. Full `dart test` suite passes; the touched files are `dart analyze`-clean (the repo's pre-existing `example/` analyzer warnings are unchanged by this PR).

## Provenance & scope

Extracted from a downstream fork built for a Flutter icon-font generator. The general engine capabilities (explicit codepoints, deterministic output, cmap safety) are what I'm proposing here. An icon-font-specific policy layer — restricting explicit codepoints to the Private Use Area to match the OS/2 `ulUnicodeRange` coverage that tool advertises — is intentionally kept downstream, since a general engine user may legitimately want other BMP blocks. Happy to split these commits into separate PRs or adjust scope however you prefer.